### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SGActionView
 ============
 
-##介绍
+## 介绍
 
 SGActionView提供三种弹出视图:  
 
@@ -12,7 +12,7 @@ SGActionView提供三种弹出视图:
 * SGSheetMenu，一个选项列表，可以设置默认值。    
 ![sheet](sheet.png)
 
-##使用
+## 使用
 
 引入`SGActionView.h`  
 
@@ -46,7 +46,7 @@ SGActionView提供三种弹出视图:
 	                                       [UIImage imageNamed:@"dropbox"]]
 	                     selectedHandle:nil];
 
-##License
+## License
 The MIT License (MIT)
 
 Copyright (c) [2014] [Sagi]


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
